### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Apple Notifier MCP Server
 
+[![smithery badge](https://smithery.ai/badge/apple-notifier-mcp)](https://smithery.ai/server/apple-notifier-mcp)
 Send native macOS notifications and interact with system dialogs through any MCP-compatible client like Claude Desktop or Cline.
 
 <a href="https://glama.ai/mcp/servers/t1w1dq4wy4"><img width="380" height="200" src="https://glama.ai/mcp/servers/t1w1dq4wy4/badge" alt="apple-notifier-mcp MCP server" /></a>
@@ -12,6 +13,15 @@ Send native macOS notifications and interact with system dialogs through any MCP
 
 ## Installation
 
+### Installing via Smithery
+
+To install Apple Notifier for Claude Desktop automatically via [Smithery](https://smithery.ai/server/apple-notifier-mcp):
+
+```bash
+npx -y @smithery/cli install apple-notifier-mcp --client claude
+```
+
+### Manual Installation
 1. Install the package globally:
 ```bash
 npm install -g apple-notifier-mcp


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Apple Notifier for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/apple-notifier-mcp

Let me know if any tweaks have to be made!